### PR TITLE
Ajustes a migrations/reservations

### DIFF
--- a/database/migrations/1669317722107_reservations.ts
+++ b/database/migrations/1669317722107_reservations.ts
@@ -7,8 +7,12 @@ export default class extends BaseSchema {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id')
       table.date('date').notNullable()
-      table.dateTime('hour', { useTz: true }).defaultTo(this.now())
-      table.string('status', 100).notNullable()
+      // table.dateTime('hour', { useTz: true }).defaultTo(this.now()) asi estaba antes
+      table.time('hour')//almacena la hora dado un <input type='time'> en el formulario reserva
+
+      // table.string('status', 100).notNullable() asi estaba antes
+      table.string('status', 100).defaultTo("Pending");//cuando el usuario hace la reserva por defecto el estado es Pending
+
       /**
        * Uses timestamptz for PostgreSQL and DATETIME2 for MSSQL
        */


### PR DESCRIPTION
Se modificó unos atributos en migrations/reservations

La hora es de tipo time, el estado es "pending" por defecto

Nota: a la reserva se le asigna el id del usuario pero no se está registrando la placa del vehiculo o el id del vehiculo, como tenemos el diagrama actual habría que modificar esa parte. Pero aquí no se está haciendo esa modificación.